### PR TITLE
[J149] GitHub Passport 전략 구현, GitHub OAuth Callback 함수 구현 

### DIFF
--- a/server/.eslintrc
+++ b/server/.eslintrc
@@ -3,6 +3,9 @@
   "plugins": ["prettier", "@typescript-eslint"],
   "parser": "@typescript-eslint/parser",
   "rules": {
-    "prettier/prettier": ["error"]
+    "prettier/prettier": ["error", {
+      "endOfLine": "auto"
+    }],
+    "linebreak-style": ["error", "windows"]
   }
 }

--- a/server/.prettierrc
+++ b/server/.prettierrc
@@ -4,5 +4,6 @@
   "semi": true,
   "useTabs": false,
   "tabWidth": 2,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "endOfLine":"auto"
 }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -219,11 +219,47 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.5.tgz",
       "integrity": "sha512-H5Wn24s/ZOukBmDn03nnGTp18A60ny9AmCwnEcgJiTgSGsCO7k+NWP7zjCCbhlcnVCoI+co52dUAt9GMhOSULw=="
     },
+    "@types/oauth": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@types/oauth/-/oauth-0.9.1.tgz",
+      "integrity": "sha512-a1iY62/a3yhZ7qH7cNUsxoI3U/0Fe9+RnuFrpTKr+0WVOzbKlSLojShCKe20aOD1Sppv+i8Zlq0pLDuTJnwS4A==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
+    },
+    "@types/passport": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.4.tgz",
+      "integrity": "sha512-h5OfAbfBBYSzjeU0GTuuqYEk9McTgWeGQql9g3gUw2/NNCfD7VgExVRYJVVeU13Twn202Mvk9BT0bUrl30sEgA==",
+      "requires": {
+        "@types/express": "*"
+      }
+    },
+    "@types/passport-github": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/passport-github/-/passport-github-1.1.5.tgz",
+      "integrity": "sha512-BeWDdLRWfPpJcmT1XofY5r1Av//TcxBEgllY4LnArcYdGqbIIVLyHwR+8bIG+ZC4PwJ6W1trnVEG3EQ+5J+Jmw==",
+      "requires": {
+        "@types/express": "*",
+        "@types/passport": "*",
+        "@types/passport-oauth2": "*"
+      }
+    },
+    "@types/passport-oauth2": {
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/@types/passport-oauth2/-/passport-oauth2-1.4.9.tgz",
+      "integrity": "sha512-QP0q+NVQOaIu2r0e10QWkiUA0Ya5mOBHRJN0UrI+LolMLOP1/VN4EVIpJ3xVwFo+xqNFRoFvFwJhBvKnk7kpUA==",
+      "requires": {
+        "@types/express": "*",
+        "@types/oauth": "*",
+        "@types/passport": "*"
+      }
     },
     "@types/qs": {
       "version": "6.9.5",
@@ -540,6 +576,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
     },
     "basic-auth": {
       "version": "2.0.1",
@@ -3527,6 +3568,11 @@
         "path-key": "^3.0.0"
       }
     },
+    "oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha1-vR/vr2hslrdUda7VGWQS/2DPucE="
+    },
     "object-inspect": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
@@ -3723,6 +3769,40 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
+    "passport": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.4.1.tgz",
+      "integrity": "sha512-IxXgZZs8d7uFSt3eqNjM9NQ3g3uQCW5avD8mRNoXV99Yig50vjuaez6dQK2qC0kVWPRTujxY0dWgGfT09adjYg==",
+      "requires": {
+        "passport-strategy": "1.x.x",
+        "pause": "0.0.1"
+      }
+    },
+    "passport-github": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/passport-github/-/passport-github-1.1.0.tgz",
+      "integrity": "sha1-jOHj/NYa11eOsd9ZWDnkrqEjVdQ=",
+      "requires": {
+        "passport-oauth2": "1.x.x"
+      }
+    },
+    "passport-oauth2": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.5.0.tgz",
+      "integrity": "sha512-kqBt6vR/5VlCK8iCx1/KpY42kQ+NEHZwsSyt4Y6STiNjU+wWICG1i8ucc1FapXDGO15C5O5VZz7+7vRzrDPXXQ==",
+      "requires": {
+        "base64url": "3.x.x",
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x",
+        "utils-merge": "1.x.x"
+      }
+    },
+    "passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
+    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -3763,6 +3843,11 @@
       "requires": {
         "pify": "^2.0.0"
       }
+    },
+    "pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
     },
     "picomatch": {
       "version": "2.2.2",
@@ -4683,6 +4768,11 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
       "integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
       "dev": true
+    },
+    "uid2": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
+      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
     },
     "umzug": {
       "version": "2.3.0",

--- a/server/package.json
+++ b/server/package.json
@@ -19,12 +19,16 @@
   "dependencies": {
     "@types/cookie-parser": "^1.4.2",
     "@types/morgan": "^1.9.1",
+    "@types/passport": "^1.0.4",
+    "@types/passport-github": "^1.1.5",
     "cookie-parser": "~1.4.4",
     "debug": "~2.6.9",
     "dotenv": "^8.2.0",
     "express": "~4.16.1",
     "morgan": "~1.9.1",
     "mysql2": "^2.2.5",
+    "passport": "^0.4.1",
+    "passport-github": "^1.1.0",
     "sequelize": "^6.3.5",
     "sequelize-cli": "^6.2.0"
   },

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -1,6 +1,9 @@
 import express, { Request, Response } from 'express';
+import userRouter from './user/user-routes';
 
 const router = express.Router();
+
+router.use('/user', userRouter);
 
 router.get('/', (req: Request, res: Response) => {
   return res.json({ result: 'true' });

--- a/server/src/api/user/user-routes.ts
+++ b/server/src/api/user/user-routes.ts
@@ -1,0 +1,19 @@
+import express from 'express';
+import passport from '../../passport/user-github';
+
+const router: express.Router = express.Router();
+
+// GitHub Login
+router.get('/github', passport.authenticate('github'));
+
+router.get(
+  '/github/callback',
+  passport.authenticate('github', { session: false }),
+  (req: express.Request, res: express.Response, next) => {
+    res.cookie('token', 'test', { maxAge: 10000000, httpOnly: true });
+    res.redirect('http://localhost:3001/');
+    // res.json(req.user);
+  },
+);
+
+export default router;

--- a/server/src/middlewares/init.ts
+++ b/server/src/middlewares/init.ts
@@ -11,7 +11,7 @@ const initMiddlewares = (app: express.Application) => {
   app.use(express.json());
   app.use(express.urlencoded({ extended: false }));
   app.use(cookieParser());
-  app.use(apiRouter);
+  app.use('/api', apiRouter);
 };
 
 export default initMiddlewares;

--- a/server/src/passport/user-github.ts
+++ b/server/src/passport/user-github.ts
@@ -1,0 +1,37 @@
+import passport from 'passport';
+import { Strategy as GitHubStrategy } from 'passport-github';
+
+const { models } = require('../sequelize').default;
+
+passport.use(
+  new GitHubStrategy(
+    {
+      clientID: process.env.GITHUB_CLIENT_ID as string,
+      clientSecret: process.env.GITHUB_CLIENT_SECRET as string,
+      callbackURL: process.env.GITHUB_CALLBACK_URL,
+    },
+    async (
+      accessToken: string,
+      refreshToken: string,
+      profile: any,
+      cb: Function,
+    ) => {
+      const {
+        _json: { email, name },
+      } = profile;
+
+      try {
+        const result = await models.user.findOrCreate({
+          where: { email, name },
+        });
+
+        return cb(null, result[0]);
+      } catch (error) {
+        // TODO: error 처리 템플릿 지정 및 구현
+        return cb(error);
+      }
+    },
+  ),
+);
+
+export default passport;


### PR DESCRIPTION
- [x] GitHub Passport 전략 구현
- [x] GitHub OAuth Callback 함수 구현
- [ ] 클라이언트가 응답을 LocalStorage에 저장하도록 구현

GitHub Passport 전략을 구현했습니다. 우선은 이메일과 이름만 가져와서 로그인(최초 로그인시 가입)하도록 구현했습니다.
GitHub OAuth Callback 함수를 구현했지만, 현재 리다이렉트 되는 문제 때문에 클라이언트에서 LocalStorage에 저장하지 못 하는 이슈가 있는데 추후 수정하겠습니다.

이슈 링크 https://github.com/boostcamp-2020/IssueTracker-37/issues/45