### PR TITLE
[J149] GitHub Callback 구현

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -3,8 +3,13 @@ import { BrowserRouter, Switch, Route } from 'react-router-dom';
 import { createGlobalStyle } from 'styled-components';
 
 import Index from './pages/index';
+<<<<<<< HEAD
+=======
+// import Login from './pages/Login';
+>>>>>>> 4907a08 (Feat #23 : GitHub Client Callback 페이지 구현)
 import SignInPage from './pages/SignInPage';
 import SignUpPage from './pages/SignUpPage';
+import GitHubCallbackPage from './pages/GitHubCallbackPage';
 
 const GolbalStyled = createGlobalStyle`
   * {
@@ -23,6 +28,11 @@ const App = () => {
         <Route path="/" exact component={Index}></Route>
         <Route path="/signin" exact component={SignInPage}></Route>
         <Route path="/signup" exact component={SignUpPage}></Route>
+        <Route
+          path="/github_callback"
+          exact
+          component={GitHubCallbackPage}
+        ></Route>
       </Switch>
     </BrowserRouter>
   );

--- a/client/src/pages/GitHubCallbackPage.js
+++ b/client/src/pages/GitHubCallbackPage.js
@@ -1,0 +1,24 @@
+import React, { useEffect } from 'react';
+import { useHistory } from 'react-router-dom';
+
+const deleteCookie = (name) => {
+  var date = new Date();
+  document.cookie = name + '= ' + '; expires=' + date.toUTCString();
+};
+
+const GitHubCallbackPage = () => {
+  const history = useHistory();
+
+  useEffect(() => {
+    const token = document.cookie.match(/(?<=(token=)).*/)[0];
+
+    localStorage.setItem('authorization', token);
+    deleteCookie('token');
+
+    history.push('/');
+  }, []);
+
+  return <></>;
+};
+
+export default GitHubCallbackPage;

--- a/server/src/api/user/user-controller.js
+++ b/server/src/api/user/user-controller.js
@@ -1,6 +1,8 @@
 const userService = require('@services/user-service');
 const { errorMessage, succeedMessage } = require('@utils/server-message');
 
+const CLIENT_OAUTH_CALLBACK_URL = 'http://localhost:8080/github_callback';
+
 class UserController {
   signup(req, res) {
     try {
@@ -15,6 +17,19 @@ class UserController {
       res
         .status(400)
         .send({ state: 'fail', message: errorMessage.failedRegister });
+    }
+  }
+
+  gitHubCallback(req, res) {
+    try {
+      // TODO: 토큰 생성 함수 구현
+      res
+        .cookie('token', 'temp token string')
+        .redirect(CLIENT_OAUTH_CALLBACK_URL);
+    } catch (error) {
+      res
+        .status(500)
+        .send({ state: 'fail', message: errorMessage.failedIssueToken });
     }
   }
 }

--- a/server/src/api/user/user-routes.js
+++ b/server/src/api/user/user-routes.js
@@ -1,9 +1,18 @@
 const express = require('express');
 
 const userController = require('@api/user/user-controller');
+const passport = require('@passport');
 
 const router = express.Router();
 
 router.post('/signup', userController.signup);
+
+router.get('/github', passport.authenticate('github'));
+
+router.get(
+  '/github/callback',
+  passport.authenticate('github', { session: false }),
+  userController.gitHubCallback,
+);
 
 module.exports = router;

--- a/server/src/utils/server-message.js
+++ b/server/src/utils/server-message.js
@@ -7,6 +7,7 @@ const errorMessage = {
   failedDelete: `데이터 삭제에 실패하였습니다.`,
   failedSelect: `데이터를 정상적으로 가져오는데 실패하였습니다.`,
   failedRegister: `회원가입에 실패했습니다.`,
+  failedIssueToken: `토큰 발행에 실패했습니다.`,
   duplicatedUser: `이미 존재하는 아이디 입니다.`,
 };
 


### PR DESCRIPTION
### 작업 사항
- [x] token 발행 실패 메시지 추가
- [x] GitHub 라우트, GitHunCallback 라우트, 컨트롤러 함수 구현
- [x] Client 사이드 callback 처리 페이지 구현


### 요약
GitHub에서 인증이 되면 클라이언트의 /github_callback 페이지로 이동해서 cookie에 저장된 토큰을 localstorage로 저장 후, cookie를 삭제해주도록 구현했습니다.

