### PR TITLE
[J118] 댓글삭제, 해당이슈 milestone 삭제, 해당이슈 assignee 등록 API

### DIFF
--- a/server/src/api/index.js
+++ b/server/src/api/index.js
@@ -1,8 +1,10 @@
 const express = require('express');
 const userRouter = require('@api/user/user-routes');
+const issueRouter = require('@api/issue/issue-router');
 
 const router = express.Router();
 
 router.use('/user', userRouter);
+router.use('/issue', issueRouter);
 
 module.exports = router;

--- a/server/src/api/issue/issue-controller.js
+++ b/server/src/api/issue/issue-controller.js
@@ -21,6 +21,26 @@ class IssueController {
         .send({ state: 'fail', message: errorMessage.failedDelete });
     }
   }
+
+  async deleteMilestoneByIssue(req, res) {
+    try {
+      const payload = {
+        id: req.params.issue_id,
+        milestone_id: req.params.milestone_id,
+      };
+      const isDeleted = await issueService.deleteMilestoneByIssue(payload);
+
+      if (isDeleted) {
+        res
+          .status(200)
+          .send({ state: 'success', message: succeedMessage.succeedDelete });
+      }
+    } catch (error) {
+      res
+        .status(400)
+        .send({ state: 'fail', message: errorMessage.failedDelete });
+    }
+  }
 }
 
 const issueController = new IssueController();

--- a/server/src/api/issue/issue-controller.js
+++ b/server/src/api/issue/issue-controller.js
@@ -41,6 +41,23 @@ class IssueController {
         .send({ state: 'fail', message: errorMessage.failedDelete });
     }
   }
+
+  async insertAssigneeByIssue(req, res) {
+    try {
+      const payload = req.params;
+      const isInserted = await issueService.insertAssigneeByIssue(payload);
+
+      if (isInserted) {
+        res
+          .status(200)
+          .send({ state: 'success', message: succeedMessage.succeedInsert });
+      }
+    } catch (error) {
+      res
+        .status(400)
+        .send({ state: 'fail', message: errorMessage.failedInsert });
+    }
+  }
 }
 
 const issueController = new IssueController();

--- a/server/src/api/issue/issue-controller.js
+++ b/server/src/api/issue/issue-controller.js
@@ -1,0 +1,28 @@
+const issueService = require('@services/issue-service');
+const { errorMessage, succeedMessage } = require('@utils/server-message');
+
+class IssueController {
+  async deleteCommentByIssue(req, res) {
+    try {
+      const payload = {
+        issue_id: req.params.issue_id,
+        id: req.params.comment_id,
+      };
+      const isDeleted = await issueService.deleteCommentByIssue(payload);
+
+      if (isDeleted) {
+        res
+          .status(200)
+          .send({ state: 'success', message: succeedMessage.succeedDelete });
+      }
+    } catch (error) {
+      res
+        .status(400)
+        .send({ state: 'fail', message: errorMessage.failedDelete });
+    }
+  }
+}
+
+const issueController = new IssueController();
+
+module.exports = issueController;

--- a/server/src/api/issue/issue-router.js
+++ b/server/src/api/issue/issue-router.js
@@ -14,4 +14,9 @@ router.delete(
   issueController.deleteMilestoneByIssue,
 );
 
+router.post(
+  '/:issue_id/assignee/:assignee_id',
+  issueController.insertAssigneeByIssue,
+);
+
 module.exports = router;

--- a/server/src/api/issue/issue-router.js
+++ b/server/src/api/issue/issue-router.js
@@ -1,0 +1,12 @@
+const express = require('express');
+
+const issueController = require('@api/issue/issue-controller');
+
+const router = express.Router();
+
+router.delete(
+  '/:issue_id/comment/:comment_id',
+  issueController.deleteCommentByIssue,
+);
+
+module.exports = router;

--- a/server/src/api/issue/issue-router.js
+++ b/server/src/api/issue/issue-router.js
@@ -9,4 +9,9 @@ router.delete(
   issueController.deleteCommentByIssue,
 );
 
+router.delete(
+  '/:issue_id/milestone/:milestone_id',
+  issueController.deleteMilestoneByIssue,
+);
+
 module.exports = router;

--- a/server/src/sequelize/models/comment-model.js
+++ b/server/src/sequelize/models/comment-model.js
@@ -18,6 +18,13 @@ class Comment extends Model {
       },
     );
   }
+
+  static async deleteCommentByIssue(payload) {
+    const result = await this.destroy({ where: payload });
+
+    if (!result) throw new Error();
+    return result;
+  }
 }
 
 module.exports = Comment;

--- a/server/src/sequelize/models/issue-model.js
+++ b/server/src/sequelize/models/issue-model.js
@@ -34,6 +34,14 @@ class Issue extends Model {
     if (!result) throw new Error();
     return result;
   }
+
+  static async insertAssigneeByIssue(payload) {
+    const result = await this.findByPk(payload.issue_id);
+
+    await result.addUser(payload.assginee_id);
+
+    return result;
+  }
 }
 
 module.exports = Issue;

--- a/server/src/sequelize/models/issue-model.js
+++ b/server/src/sequelize/models/issue-model.js
@@ -27,6 +27,13 @@ class Issue extends Model {
       },
     );
   }
+
+  static async deleteMilestoneByIssue(payload) {
+    const result = await this.destroy({ where: payload });
+
+    if (!result) throw new Error();
+    return result;
+  }
 }
 
 module.exports = Issue;

--- a/server/src/services/issue-service.js
+++ b/server/src/services/issue-service.js
@@ -1,0 +1,13 @@
+const commentModel = require('@models/comment-model');
+
+class IssueService {
+  async deleteCommentByIssue(payload) {
+    const isDeleted = await commentModel.deleteCommentByIssue(payload);
+
+    return isDeleted;
+  }
+}
+
+const issueService = new IssueService();
+
+module.exports = issueService;

--- a/server/src/services/issue-service.js
+++ b/server/src/services/issue-service.js
@@ -13,6 +13,12 @@ class IssueService {
 
     return isDeleted;
   }
+
+  async insertAssigneeByIssue(payload) {
+    const isInserted = await issueModel.insertAssigneeByIssue(payload);
+
+    return isInserted;
+  }
 }
 
 const issueService = new IssueService();

--- a/server/src/services/issue-service.js
+++ b/server/src/services/issue-service.js
@@ -1,8 +1,15 @@
 const commentModel = require('@models/comment-model');
+const issueModel = require('@models/issue-model');
 
 class IssueService {
   async deleteCommentByIssue(payload) {
     const isDeleted = await commentModel.deleteCommentByIssue(payload);
+
+    return isDeleted;
+  }
+
+  async deleteMilestoneByIssue(payload) {
+    const isDeleted = await issueModel.deleteMilestoneByIssue(payload);
 
     return isDeleted;
   }


### PR DESCRIPTION
### 작업 사항
- [x] 댓글 삭제 API
- [x] 해당이슈 마일스톤 삭제 API
- [ ] 해당이슈 assignee 등록 API


### 요약
model에서 쿼리가 정상적으로 동작하지 않을 경우 에러를 던지도록 구현함.


### 첨부
![image](https://user-images.githubusercontent.com/52775389/97973846-0bb74b00-1e0a-11eb-961f-e4b3363fecee.png)