### PR TITLE
[J118] passport jwt, local 전략, signin 기능 구현, atomic design 패턴 일부구현

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2380,6 +2380,11 @@
         }
       }
     },
+    "classnames": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+    },
     "clean-css": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "axios": "^0.21.0",
     "babel-polyfill": "^6.26.0",
+    "classnames": "^2.2.6",
     "eslint-config-naver": "^2.1.0",
     "prop-types": "^15.7.2",
     "react-router-dom": "^5.2.0",

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { BrowserRouter, Switch, Route } from 'react-router-dom';
 import { createGlobalStyle } from 'styled-components';
 
+import Auth from '@hoc/Auth';
 import Index from './pages/index';
 import SignInPage from './pages/SignInPage';
 import SignUpPage from './pages/SignUpPage';
@@ -21,9 +22,9 @@ const App = () => {
     <BrowserRouter>
       <GolbalStyled />
       <Switch>
-        <Route path="/" exact component={Index}></Route>
-        <Route path="/signin" exact component={SignInPage}></Route>
-        <Route path="/signup" exact component={SignUpPage}></Route>
+        <Route path="/" exact component={Auth(Index, true)}></Route>
+        <Route path="/signin" exact component={Auth(SignInPage, false)}></Route>
+        <Route path="/signup" exact component={Auth(SignUpPage, false)}></Route>
         <Route
           path="/github_callback"
           exact

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -3,7 +3,8 @@ import { BrowserRouter, Switch, Route } from 'react-router-dom';
 import { createGlobalStyle } from 'styled-components';
 
 import Auth from '@hoc/Auth';
-import Index from './pages/index';
+// import Index from './pages/index';
+import Main from './pages/Main';
 import SignInPage from './pages/SignInPage';
 import SignUpPage from './pages/SignUpPage';
 import GitHubCallbackPage from './pages/GitHubCallbackPage';
@@ -11,6 +12,9 @@ import GitHubCallbackPage from './pages/GitHubCallbackPage';
 const GolbalStyled = createGlobalStyle`
   * {
     box-sizing: border-box;
+    border: 0;
+    margin: 0;
+    padding: 0;
   }
   input {
     -webkit-appearance: none;
@@ -22,7 +26,8 @@ const App = () => {
     <BrowserRouter>
       <GolbalStyled />
       <Switch>
-        <Route path="/" exact component={Auth(Index, true)}></Route>
+        <Route path="/" exact component={Auth(Main, false)}></Route>
+        {/* <Route path="/" exact component={Auth(Index, false)}></Route> */}
         <Route path="/signin" exact component={Auth(SignInPage, false)}></Route>
         <Route path="/signup" exact component={Auth(SignUpPage, false)}></Route>
         <Route

--- a/client/src/components/atoms/Button/index.js
+++ b/client/src/components/atoms/Button/index.js
@@ -1,16 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import cn from 'classnames';
 
 import { StyledButton } from './style';
 
 const Button = (props) => {
-  const { afterContent, children, onClick, buttonType } = props;
+  const { afterContent, children, onClick, buttonType, className } = props;
 
   return (
     <StyledButton
       buttonType={buttonType}
       afterContent={afterContent}
       onClick={onClick}
+      className={cn(className)}
     >
       {children}
     </StyledButton>
@@ -18,7 +20,7 @@ const Button = (props) => {
 };
 
 Button.defaultProps = {
-  onClick: () => {},
+  onClick: () => { },
 };
 
 Button.propTypes = {
@@ -27,6 +29,7 @@ Button.propTypes = {
   children: PropTypes.string,
   type: PropTypes.string,
   buttonType: PropTypes.string,
+  className: PropTypes.string,
 };
 
 export default Button;

--- a/client/src/components/atoms/Input/index.js
+++ b/client/src/components/atoms/Input/index.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
+import cn from 'classnames';
 import { StyledInput } from './style';
 
 const Input = (props) => {
-  const { type, value, name, placeholder, id, onChange } = props;
+  const { type, value, name, placeholder, id, onChange, className } = props;
 
   return (
     <StyledInput
@@ -14,6 +14,7 @@ const Input = (props) => {
       placeholder={placeholder}
       id={id}
       onChange={onChange}
+      className={cn(className)}
     />
   );
 };
@@ -21,7 +22,7 @@ const Input = (props) => {
 Input.defaultProps = {
   type: 'text',
   placeholder: '',
-  onChange: () => {},
+  onChange: () => { },
 };
 
 Input.propTypes = {
@@ -31,6 +32,7 @@ Input.propTypes = {
   value: PropTypes.string,
   name: PropTypes.string,
   id: PropTypes.string,
+  className: PropTypes.string,
 };
 
 export default Input;

--- a/client/src/components/atoms/Span/index.js
+++ b/client/src/components/atoms/Span/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import cn from 'classnames';
 
 import { StyledSpan } from './style';
 
@@ -11,6 +12,7 @@ const Span = (props) => {
     hoverColor,
     afterContent,
     color,
+    className,
   } = props;
 
   return (
@@ -20,6 +22,7 @@ const Span = (props) => {
       hoverColor={hoverColor}
       afterContent={afterContent}
       color={color}
+      className={cn(className)}
     >
       {children}
     </StyledSpan>
@@ -37,6 +40,7 @@ Span.propTypes = {
   hoverColor: PropTypes.string,
   afterContent: PropTypes.string,
   color: PropTypes.string,
+  className: PropTypes.string,
 };
 
 export default Span;

--- a/client/src/components/molecules/ImgTitle/index.js
+++ b/client/src/components/molecules/ImgTitle/index.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Img from '@atoms/Img';
+import Span from '@atoms/Span';
+
+import { StyledImgTitle } from './style';
+
+const ImgTitle = (props) => {
+  const { src, alt, children, styleType } = props;
+
+  return (
+    <StyledImgTitle className={styleType}>
+      <Img src={src} alt={alt}></Img>
+      <Span>{children}</Span>
+    </StyledImgTitle>
+  );
+};
+
+ImgTitle.defaultProps = {};
+
+ImgTitle.propTypes = {
+  src: PropTypes.string,
+  alt: PropTypes.string,
+  children: PropTypes.string,
+  styleType: PropTypes.string,
+};
+
+export default ImgTitle;

--- a/client/src/components/molecules/ImgTitle/style.js
+++ b/client/src/components/molecules/ImgTitle/style.js
@@ -1,0 +1,20 @@
+import styled from 'styled-components';
+
+export const StyledImgTitle = styled.div`
+  display: flex;
+  align-items: center;
+
+  &.header {
+    & > span {
+      margin-left: 5px;
+      color: white;
+    }
+  }
+
+  &.button {
+    & > span {
+      color: #586069;
+      margin-left: 10px;
+    }
+  }
+`;

--- a/client/src/components/molecules/ImgTitleCount/index.js
+++ b/client/src/components/molecules/ImgTitleCount/index.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Img from '@atoms/Img';
+import Span from '@atoms/Span';
+
+import { StyledImgTitleCount } from './style';
+
+const ImgTitleCount = (props) => {
+  const { src, alt, children, count } = props;
+  const spanType = 'LARGE';
+
+  return (
+    <StyledImgTitleCount>
+      <Img src={src} alt={alt}></Img>
+      <Span spanType={spanType} color="GRAY">
+        {children}
+      </Span>
+      <Span spanType={spanType} className="round">
+        {count}
+      </Span>
+    </StyledImgTitleCount>
+  );
+};
+
+ImgTitleCount.defaultProps = {};
+
+ImgTitleCount.propTypes = {
+  src: PropTypes.string,
+  alt: PropTypes.string,
+  children: PropTypes.string,
+  styleType: PropTypes.string,
+  count: PropTypes.string,
+};
+
+export default ImgTitleCount;

--- a/client/src/components/molecules/ImgTitleCount/style.js
+++ b/client/src/components/molecules/ImgTitleCount/style.js
@@ -1,0 +1,23 @@
+import styled from 'styled-components';
+
+export const StyledImgTitleCount = styled.div`
+  display: inline-flex;
+  align-items: center;
+  padding: 5px 16px;
+
+  &:hover {
+    background-color: #f6f8fa;
+  }
+
+  & > img {
+    margin-right: 10px;
+  }
+
+  & > span.round {
+    margin-left: 10px;
+    padding: 0 6px;
+    color: #24292e;
+    background-color: #d1d5da80;
+    border-radius: 50%;
+  }
+`;

--- a/client/src/components/molecules/SearchBox/index.js
+++ b/client/src/components/molecules/SearchBox/index.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Input from '@atoms/Input';
+import Button from '@atoms/Button';
+
+import { StyledSearchBox } from './style';
+
+const SearchBox = (props) => {
+  const {
+    type,
+    value,
+    name,
+    placeholder,
+    id,
+    afterContent,
+    onChange,
+    onClick,
+    children,
+  } = props;
+
+  const searchbar = 'searchbox';
+
+  return (
+    <StyledSearchBox>
+      <Button
+        onClick={onClick}
+        afterContent={afterContent}
+        className={searchbar}
+      >
+        {children}
+      </Button>
+      <Input
+        type={type}
+        value={value}
+        name={name}
+        placeholder={placeholder}
+        id={id}
+        onChange={onChange}
+        className={searchbar}
+      />
+    </StyledSearchBox>
+  );
+};
+
+SearchBox.defaultProps = {};
+
+SearchBox.propTypes = {
+  type: PropTypes.string,
+  value: PropTypes.string,
+  name: PropTypes.string,
+  placeholder: PropTypes.string,
+  id: PropTypes.string,
+  afterContent: PropTypes.string,
+  children: PropTypes.string,
+  onChange: PropTypes.func,
+  onClick: PropTypes.func,
+};
+
+export default SearchBox;

--- a/client/src/components/molecules/SearchBox/style.js
+++ b/client/src/components/molecules/SearchBox/style.js
@@ -1,0 +1,25 @@
+import styled from 'styled-components';
+
+export const StyledSearchBox = styled.div`
+  border: 1px solid black;
+  border-radius: 5px;
+  width: 40%;
+  & > button.searchbox {
+    border: none;
+    border-radius: 0;
+    border-left-top-radius: 5px;
+    border-left-bottom-radius: 5px;
+    border-right: 1px solid rgba(27, 31, 35, 0.15);
+  }
+
+  & > button.searchbox:hover {
+    background-color: #d1d5da80;
+  }
+
+  & > input.searchbox {
+    padding: 5px 12px 5px 32px;
+    border: none;
+    border-rigth-top: 5px;
+    border-rigth-bottom: 5px;
+  }
+`;

--- a/client/src/components/organisms/Header/index.js
+++ b/client/src/components/organisms/Header/index.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { useHistory } from 'react-router-dom';
+
+import ImgTitle from '@molecules/ImgTitle';
+import Button from '@atoms/Button';
+import { StyledHeader } from './style';
+
+const Header = () => {
+  const history = useHistory();
+
+  return (
+    <>
+      <StyledHeader>
+        <ImgTitle
+          styleType="header"
+          src="https://avatars3.githubusercontent.com/u/52775389?s=60&v=4"
+          alt="프로필 기본 이미지"
+        >
+          ISSUE
+        </ImgTitle>
+        <Button onClick={() => history.push('/signin')}>로그아웃</Button>
+      </StyledHeader>
+    </>
+  );
+};
+
+export default Header;

--- a/client/src/components/organisms/Header/style.js
+++ b/client/src/components/organisms/Header/style.js
@@ -1,0 +1,16 @@
+import styled from 'styled-components';
+
+export const StyledHeader = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  width: 100%;
+  height: 62px;
+  background-color: #24292e;
+
+  & > button {
+    position: absolute;
+    right: 30px;
+  }
+`;

--- a/client/src/hoc/Auth.js
+++ b/client/src/hoc/Auth.js
@@ -1,0 +1,20 @@
+import React, { useEffect } from 'react';
+import { useHistory } from 'react-router-dom';
+import { isToken } from '@utils/token';
+
+const Auth = (SpecificComponent, option = null, isAdmin) => {
+  const AuthenticationCheck = () => {
+    const history = useHistory();
+
+    useEffect(() => {
+      if (isToken() || !option) history.push('/');
+      if (!isToken() || option) history.push('/signin');
+    }, []);
+
+    return <SpecificComponent></SpecificComponent>;
+  };
+
+  return AuthenticationCheck;
+};
+
+export default Auth;

--- a/client/src/hoc/Auth.js
+++ b/client/src/hoc/Auth.js
@@ -7,8 +7,8 @@ const Auth = (SpecificComponent, option = null, isAdmin) => {
     const history = useHistory();
 
     useEffect(() => {
-      if (isToken() || !option) history.push('/');
-      if (!isToken() || option) history.push('/signin');
+      // if (isToken() || !option) history.push('/');
+      // if (!isToken() || option) history.push('/signin');
     }, []);
 
     return <SpecificComponent></SpecificComponent>;

--- a/client/src/pages/Main.js
+++ b/client/src/pages/Main.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import Header from '@organisms/Header';
+import SearchBox from '@molecules/SearchBox';
+
+const main = () => {
+  return (
+    <>
+      <Header />
+      <SearchBox afterContent="▼" placeholder="is:issue is:open">
+        Filter
+      </SearchBox>
+    </>
+  );
+};
+
+export default main;

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -21,6 +21,7 @@ module.exports = {
       '@atoms': path.join(__dirname, 'src/components/atoms'),
       '@molecules': path.join(__dirname, 'src/components/molecules'),
       '@organisms': path.join(__dirname, 'src/components/organisms'),
+      '@hoc': path.join(__dirname, 'src/hoc'),
     },
   },
   mode,

--- a/server/src/api/user/user-routes.js
+++ b/server/src/api/user/user-routes.js
@@ -1,7 +1,8 @@
 const express = require('express');
+const passport = require('@passport');
 
 const userController = require('@api/user/user-controller');
-const passport = require('@passport');
+const { loginAuth } = require('@middlewares/auth');
 
 const router = express.Router();
 
@@ -14,5 +15,7 @@ router.get(
   passport.authenticate('github', { session: false }),
   userController.gitHubCallback,
 );
+
+router.post('/signin', loginAuth);
 
 module.exports = router;

--- a/server/src/middlewares/auth.js
+++ b/server/src/middlewares/auth.js
@@ -9,7 +9,7 @@ const loginAuth = async (req, res, next) => {
       if (error || !user)
         return res.status(400).json({ state: 'fail', message });
 
-      const payload = { no: user.no, id: user.user_id };
+      const payload = { no: user.id, email: user.email };
       const generateJWTToken = jwt.sign(payload, JWT_SECRET_KEY);
 
       return res.json({ state: 'success', data: { JWT: generateJWTToken } });
@@ -26,8 +26,7 @@ const apiAuth = async (req, res, next) => {
       { session: false },
       (error, user, { message } = '') => {
         if (error || !user) res.status(400).json({ state: 'fail', message });
-
-        req.body.user_no = user.no;
+        req.body.user_no = user.id;
         next();
       },
     )(req, res, next);

--- a/server/src/middlewares/passport/jwt.js
+++ b/server/src/middlewares/passport/jwt.js
@@ -1,6 +1,6 @@
 const { Strategy: JWTStrategy, ExtractJwt } = require('passport-jwt');
 const { errorMessage } = require('@utils/server-message');
-const { models } = require('@sequelize/index');
+const userModel = require('@models/user-model');
 
 const JWTConfig = {
   jwtFromRequest: ExtractJwt.fromHeader('authorization'),
@@ -9,7 +9,8 @@ const JWTConfig = {
 
 const JWTVerify = async (payload, done) => {
   try {
-    const user = await models.user.findOne({ where: { user_id: payload.id } });
+    const { no, email } = payload;
+    const user = await userModel.findOne({ where: { email, id: no } });
 
     if (user) return done(null, user);
     return done(null, false, { message: errorMessage.invalidToken });

--- a/server/src/middlewares/passport/local.js
+++ b/server/src/middlewares/passport/local.js
@@ -1,14 +1,14 @@
 const { Strategy: LocalStrategy } = require('passport-local');
 
 const { errorMessage } = require('@utils/server-message');
-const { models } = require('@sequelize/index');
+const userModel = require('@models/user-model');
 const { isComparedPassword } = require('@utils/bcrypt');
 
 const passportConfig = { usernameField: 'email', passwordField: 'password' };
 
 const passportAuth = async (email, password, done) => {
   try {
-    const user = await models.user.findOne({ where: { email } });
+    const user = await userModel.findOne({ where: { email } });
 
     if (!user) return done(null, false, { message: errorMessage.invalidUser });
     if (isComparedPassword(password, user.password)) return done(null, user);

--- a/server/src/sequelize/models/issue-model.js
+++ b/server/src/sequelize/models/issue-model.js
@@ -105,17 +105,24 @@ class Issue extends Model {
   }
 
   static async deleteMilestoneByIssue(payload) {
-    const result = await this.destroy({ where: payload });
+    const isIssued = await this.findOne({ where: payload });
 
-    if (!result) throw new Error();
+    if (!isIssued) throw new Error();
 
-    return result;
+    const [isDeleted] = await this.update(
+      { milestone_id: null },
+      { where: payload },
+    );
+
+    if (!isDeleted) throw new Error();
+
+    return isDeleted;
   }
 
   static async insertAssigneeByIssue(payload) {
     const result = await this.findByPk(payload.issue_id);
 
-    await result.addUser(payload.assginee_id);
+    await result.addUser(payload.assignee_id);
 
     return result;
   }

--- a/server/src/services/issue-service.js
+++ b/server/src/services/issue-service.js
@@ -1,6 +1,7 @@
-const milestoneModel = require('@models/milestone-model');
+// const milestoneModel = require('@models/milestone-model');
 const labelModel = require('@models/label-model');
 const commentModel = require('@models/comment-model');
+const issueModel = require('@models/issue-model');
 
 class IssueService {
   async deleteCommentByIssue(payload) {
@@ -39,6 +40,7 @@ class IssueService {
 
   async getIssues() {
     const issues = await issueModel.getIssues();
+
     return issues;
   }
 


### PR DESCRIPTION
### 작업 사항
- [x] passport local 전략 구현
- [x] passport jwt 전략 구현
- [x] signin 기능 구현
- [x] 해당 이슈 유저 등록 API 구현
- [x] 해당 이슈 마일스톤 삭제 API 구현
- [x] ImgTitle molecules 구현
- [x] ImgTitleCount molecules 구현
- [x] SearchBox molecules 구현
- [x] Header organisms 구현
- [x] Atom 요소들에 classnames 라이브러리 적용

### 요약
api 인증에 성공하면 req.body.user_no 에 유저 번호를 저장하도록 구현했습니다.
로그인 성공 시 토큰을 보내주도록 구현했습니다.

molecules 요소에서 atom 요소에 classname 전달하기 위해서 classnames 라이브러리 설치하였습니다.


### 첨부
- jwt 토큰 인증 시 유저 번호 제대로 저장되는지 테스트한 화면
![image](https://user-images.githubusercontent.com/52775389/98105231-00802000-1edb-11eb-9e17-235413268707.png)
